### PR TITLE
Group and Expense CircuitBreaker and fallback strategy

### DIFF
--- a/deployable/ExpenseService/Controller/ExpenseController.cs
+++ b/deployable/ExpenseService/Controller/ExpenseController.cs
@@ -3,6 +3,9 @@ using Messages.Expense.Request;
 using Messages.Expense.Response;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
+using System.Text.Json;
+using Polly;
+using Polly.CircuitBreaker;
 using RPC;
 
 namespace ExpenseService.Controller;
@@ -10,79 +13,115 @@ namespace ExpenseService.Controller;
 [ApiController]
 [Route("expense")]
 public class ExpenseController : ControllerBase {
-
     private readonly RpcClient _rpcClient;
+    private readonly IAsyncPolicy<HttpResponseMessage> _policies;
+    private readonly IHttpClientFactory _clientFactory;
 
-    public ExpenseController(RpcClient rpcClient) {
+    public ExpenseController(RpcClient rpcClient, IAsyncPolicy<HttpResponseMessage> policies, IHttpClientFactory clientFactory) {
         _rpcClient = rpcClient;
+        _policies = policies;
+        _clientFactory = clientFactory;
     }
 
-    /// <summary>
-    /// Retrieves all the expenses from a user in a group. Returns an empty list if no expenses were found.
-    /// <br/>- Sends a request through RPC to:
-    /// <br/>- ExpenseRepository
-    /// </summary>
-    /// <param name="groupId"><see cref="int"/></param>
-    /// <param name="userId"><see cref="int"/></param>
-    /// <returns>A <see cref="IActionResult"/> containing an <see cref="List{T}"/> of <see cref="ExpenseResponse"/> objects.</returns>
     [HttpGet("{groupId}/user/{userId}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<ExpenseResponse>))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof (string))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(string))]
     public async Task<ActionResult<List<ExpenseResponse>>> GetExpensesFromUser([FromRoute] int groupId, [FromRoute] int userId) {
         try {
             var request = new GetExpensesUserReq() {
                 UserId = userId,
                 GroupId = groupId
             };
-            var response = await _rpcClient.CallAsync(Operation.GetExpensesFromUserInGroup, request);
-            var expenses = JsonConvert.DeserializeObject<List<ExpenseResponse>>(response);
+
+            var response = await _policies.ExecuteAsync(async () =>
+            {
+                var rpcResponse = await _rpcClient.CallAsync(Operation.GetExpensesFromUserInGroup, request);
+                return new HttpResponseMessage()
+                {
+                    Content = new StringContent(rpcResponse)
+                };
+            });
+
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var expenses = JsonConvert.DeserializeObject<List<ExpenseResponse>>(responseContent);
             return Ok(expenses);
-        } catch (Exception e) {
+        }
+        catch (BrokenCircuitException)
+        {
+            Monitoring.Monitoring.Log.Error("GetExpensesFromUser::Circuit breaker is open, fallback strategy launched.");
+            var client = _clientFactory.CreateClient("ExpenseRepoHTTP");
+            var response = await client.GetAsync($"http://expense-repo:8080/expense/{groupId}/user/{userId}");
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            var result = System.Text.Json.JsonSerializer.Deserialize<List<ExpenseResponse>>(jsonResponse,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return Ok(result);
+        }
+        catch (RpcTimeoutException)
+        {
+            return StatusCode(StatusCodes.Status408RequestTimeout, "Request timed out");
+        }
+        catch (Exception e)
+        {
+            Monitoring.Monitoring.Log.Error("Error getting expenses from user in group");
             Console.WriteLine(e);
             return BadRequest("Error getting expenses from user in group");
         }
     }
 
-    /// <summary>
-    /// Retrieves all the expenses from a group. Returns an empty list if no expenses were found.
-    /// <br/>- Sends a request through RPC to:
-    /// <br/>- ExpenseRepository
-    /// </summary>
-    /// <param name="groupId"><see cref="int"/></param>
-    /// <returns>A <see cref="IActionResult"/> containing an <see cref="List{T}"/> of <see cref="ExpenseResponse"/> objects.</returns>
     [HttpGet("{groupId}/expenses")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<ExpenseResponse>))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof (string))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(string))]
     public async Task<ActionResult<List<ExpenseResponse>>> GetExpensesFromGroup([FromRoute] int groupId) {
         try {
             var request = new GetExpensesReq() {
                 GroupId = groupId
             };
-            var response = await _rpcClient.CallAsync(Operation.GetExpensesFromGroup, request);
-            var expenses = JsonConvert.DeserializeObject<List<ExpenseResponse>>(response);
+
+            var response = await _policies.ExecuteAsync(async () =>
+            {
+                var rpcResponse = await _rpcClient.CallAsync(Operation.GetExpensesFromGroup, request);
+                return new HttpResponseMessage()
+                {
+                    Content = new StringContent(rpcResponse)
+                };
+            });
+
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var expenses = JsonConvert.DeserializeObject<List<ExpenseResponse>>(responseContent);
             return Ok(expenses);
-        } catch (Exception e) {
+        }
+        catch (BrokenCircuitException)
+        {
+            Monitoring.Monitoring.Log.Error("GetExpensesFromGroup::Circuit breaker is open, fallback strategy launched.");
+            var client = _clientFactory.CreateClient("ExpenseRepoHTTP");
+            var response = await client.GetAsync($"http://expense-repo:8080/expense/{groupId}/expenses");
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            var result = System.Text.Json.JsonSerializer.Deserialize<List<ExpenseResponse>>(jsonResponse,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return Ok(result);
+        }
+        catch (RpcTimeoutException)
+        {
+            return StatusCode(StatusCodes.Status408RequestTimeout, "Request timed out");
+        }
+        catch (Exception e)
+        {
+            Monitoring.Monitoring.Log.Error("Error getting expenses from group");
             Console.WriteLine(e);
             return BadRequest("Error getting expenses from group");
         }
     }
 
-    /// <summary>
-    /// Creates an expense.
-    /// <br/>- Sends a request through RPC to:
-    /// <br/>- ExpenseRepository
-    /// </summary>
-    /// <param name="request"><see cref="PostExpense"/></param>
-    /// <returns><see cref="ExpenseResponse"/></returns>
     [HttpPost]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<ExpenseResponse>))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ExpenseResponse))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof (string))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(string))]
     public async Task<ActionResult<ExpenseResponse>> Create([FromBody] PostExpense request) {
         try {
-            // Add datetime to the request
             var expenseRequest = new CreateExpenseReq {
                 Amount = request.Amount,
                 Description = request.Description,
@@ -92,10 +131,40 @@ public class ExpenseController : ControllerBase {
                 Date = request.Date
             };
 
-            var response = await _rpcClient.CallAsync(Operation.CreateExpense, expenseRequest);
-            var expense = JsonConvert.DeserializeObject<ExpenseResponse>(response);
+            var response = await _policies.ExecuteAsync(async () =>
+            {
+                var rpcResponse = await _rpcClient.CallAsync(Operation.CreateExpense, expenseRequest);
+                return new HttpResponseMessage()
+                {
+                    Content = new StringContent(rpcResponse)
+                };
+            });
+
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var expense = JsonConvert.DeserializeObject<ExpenseResponse>(responseContent);
             return Ok(expense);
-        } catch (Exception e) {
+        }
+        catch (BrokenCircuitException)
+        {
+            Monitoring.Monitoring.Log.Error("Create::Circuit breaker is open, fallback strategy launched.");
+            var client = _clientFactory.CreateClient("ExpenseRepoHTTP");
+            var jsonRequest = System.Text.Json.JsonSerializer.Serialize(request);
+            var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, "application/json");
+            var response = await client.PostAsync($"http://expense-repo:8080/expense", content);
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            var result = System.Text.Json.JsonSerializer.Deserialize<ExpenseResponse>(jsonResponse,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(result);
+        }
+        catch (RpcTimeoutException)
+        {
+            return StatusCode(StatusCodes.Status408RequestTimeout, "Request timed out");
+        }
+        catch (Exception e)
+        {
+            Monitoring.Monitoring.Log.Error("Error creating expense");
             Console.WriteLine(e);
             return BadRequest("Error creating expense");
         }

--- a/deployable/ExpenseService/ExpenseService.csproj
+++ b/deployable/ExpenseService/ExpenseService.csproj
@@ -8,11 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.2"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.2" />
+        <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\library\Monitoring\Monitoring.csproj" />
       <ProjectReference Include="..\..\library\RPC\RPC.csproj" />
       <ProjectReference Include="..\..\shared\Domain\Domain.csproj" />
       <ProjectReference Include="..\..\shared\Messages\Messages.csproj" />

--- a/deployable/ExpenseService/Program.cs
+++ b/deployable/ExpenseService/Program.cs
@@ -1,5 +1,7 @@
 ﻿using Messages.RPC;
 using Microsoft.Extensions.Options;
+using Polly;
+using Polly.Extensions.Http;
 using RPC;
 using RPC.RpcFactory;
 
@@ -10,6 +12,41 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddControllers();
+
+// HERE we add the IHttpClientFactory
+builder.Services.AddHttpClient();
+builder.Services.AddHttpClient("ExpenseRepoHTTP", client => {
+    client.BaseAddress = new Uri("http://expense-repo:8080");
+});
+// HTTP Circuit breakers
+
+var retryPolicy = HttpPolicyExtensions
+    .HandleTransientHttpError()
+    .Or<RpcTimeoutException>()
+    .WaitAndRetryAsync(1, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)), onRetry: (outcome, timespan, retryAttempt, context) =>
+    {
+        Console.WriteLine($"Retrying... attempt {retryAttempt}");
+    });
+
+var circuitBreakerPolicy = HttpPolicyExtensions
+    .HandleTransientHttpError()
+    .Or<RpcTimeoutException>()
+    .CircuitBreakerAsync(1, TimeSpan.FromSeconds(30), onBreak: (outcome, timespan) =>
+    {
+        Console.WriteLine("Circuit breaker opened!");
+    }, onReset: () =>
+    {
+        Console.WriteLine("Circuit breaker reset!");
+    });
+
+var timeoutPolicy = Policy.TimeoutAsync<HttpResponseMessage>(TimeSpan.FromSeconds(30), (context, timeSpan, task) => {
+    return Task.FromException<HttpResponseMessage>(new RpcTimeoutException("Request timed out."));
+});
+
+// Wrapping the policies in the correct order: timeoutPolicy should be the outermost
+var policies = Policy.WrapAsync( retryPolicy, circuitBreakerPolicy,timeoutPolicy);
+builder.Services.AddSingleton<IAsyncPolicy<HttpResponseMessage>>(policies);
+
 // Configure topics
 builder.Services.AddSingleton<IConnectionFactoryProvider, RpcFactory>();
 builder.Services.Configure<Topics>(builder.Configuration.GetSection("RPCMessages"));

--- a/deployable/GroupService/Controller/GroupController.cs
+++ b/deployable/GroupService/Controller/GroupController.cs
@@ -3,7 +3,10 @@ using Messages.Group.Dto;
 using Messages.Group.Request;
 using Messages.Group.Response;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
 using Newtonsoft.Json;
+using Polly;
+using Polly.CircuitBreaker;
 using RPC;
 
 namespace GroupService.Controller;
@@ -12,18 +15,15 @@ namespace GroupService.Controller;
 [Route("group")]
 public class GroupController : ControllerBase {
     private readonly RpcClient _rpcClient;
+    private readonly IAsyncPolicy<HttpResponseMessage> _policies;
+    private readonly IHttpClientFactory _clientFactory;
 
-    public GroupController(RpcClient rpcClient) {
+    public GroupController(RpcClient rpcClient, IAsyncPolicy<HttpResponseMessage> policies, IHttpClientFactory httpClientFactory) {
         _rpcClient = rpcClient;
+        _policies = policies;
+        _clientFactory = httpClientFactory;
     }
 
-    /// <summary>
-    /// Retrieves all groups from a user based on userId.
-    /// <br/> - Sends a request through RPC to:
-    /// <br/> - GroupRepository
-    /// </summary>
-    /// <param name="userId"><see cref="int"/></param>
-    /// <returns>A <see cref="IActionResult"/> containing an <see cref="List{T}"/> of <see cref="GroupResponse"/> objects.</returns>
     [HttpGet("{userId}/groups")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<GroupResponse>))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
@@ -35,29 +35,46 @@ public class GroupController : ControllerBase {
                 return BadRequest("Invalid user id");
             }
 
-            // Create request object to send to the group repository
             var groupsUserReq = new GroupsUserReq() {
                 UserId = userId
             };
 
-            // Fetches all groups from user
-            var groupResponse = await _rpcClient.CallAsync(Operation.GetGroupsFromUser, groupsUserReq);
-            var groups = JsonConvert.DeserializeObject<List<GroupResponse>>(groupResponse);
+            var response = await _policies.ExecuteAsync(async () =>
+            {
+                var rpcResponse = await _rpcClient.CallAsync(Operation.GetGroupsFromUser, groupsUserReq);
+                return new HttpResponseMessage()
+                {
+                    Content = new StringContent(rpcResponse)
+                };
+            });
+
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var groups = JsonConvert.DeserializeObject<List<GroupResponse>>(responseContent);
             return Ok(groups);
-        } catch (Exception e) {
+        }
+        catch (BrokenCircuitException)
+        {
+            Monitoring.Monitoring.Log.Error("GetAllGroupsOfUser::Circuit breaker is open, fallback strategy launched.");
+            var client = _clientFactory.CreateClient("GroupRepoHTTP");
+            var response = await client.GetAsync($"http://group-repo:8080/{userId}/groups");
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            var result = System.Text.Json.JsonSerializer.Deserialize<List<GroupResponse>>(jsonResponse,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return Ok(result);
+        }
+        catch (RpcTimeoutException)
+        {
+            return StatusCode(StatusCodes.Status408RequestTimeout, "Request timed out");
+        }
+        catch (Exception e)
+        {
             Monitoring.Monitoring.Log.Error("Error getting groups from user");
             Console.WriteLine(e);
             return StatusCode(StatusCodes.Status500InternalServerError, "Couldn't deserialize the response");
         }
     }
-    
-    /// <summary>
-    /// Retrieves a group by id.
-    /// <br/>- Sends a request through RPC to:
-    /// <br/>- GroupRepository
-    /// </summary>
-    /// <param name="groupId"><see cref="int"/></param>
-    /// <returns>An <see cref="IActionResult"/> of <see cref="GroupResponse"/></returns>
+
     [HttpGet("{groupId}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GroupResponse))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
@@ -69,30 +86,46 @@ public class GroupController : ControllerBase {
                 return BadRequest("Invalid group id");
             }
 
-            // Create request object to send to the group repository
             var groupRequest = new GroupByIdRequest() {
                 GroupId = groupId
             };
 
-            // Fetch the group
-            var groupResponse = await _rpcClient.CallAsync(Operation.GetGroupById, groupRequest);
-            var group = JsonConvert.DeserializeObject<GroupResponse>(groupResponse);
+            var response = await _policies.ExecuteAsync(async () =>
+            {
+                var rpcResponse = await _rpcClient.CallAsync(Operation.GetGroupById, groupRequest);
+                return new HttpResponseMessage()
+                {
+                    Content = new StringContent(rpcResponse)
+                };
+            });
+
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var group = JsonConvert.DeserializeObject<GroupResponse>(responseContent);
             return Ok(group);
-        } catch (Exception e) {
+        }
+        catch (BrokenCircuitException)
+        {
+            Monitoring.Monitoring.Log.Error("GetById::Circuit breaker is open, fallback strategy launched.");
+            var client = _clientFactory.CreateClient("GroupRepoHTTP");
+            var response = await client.GetAsync($"http://group-repo:8080/group/{groupId}");
+
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            var result = System.Text.Json.JsonSerializer.Deserialize<GroupResponse>(jsonResponse,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return Ok(result);
+        }
+        catch (RpcTimeoutException)
+        {
+            return StatusCode(StatusCodes.Status408RequestTimeout, "Request timed out");
+        }
+        catch (Exception e)
+        {
             Monitoring.Monitoring.Log.Error("Error getting group by id");
             Console.WriteLine(e);
             return StatusCode(StatusCodes.Status500InternalServerError, "Couldn't deserialize the response");
         }
     }
 
-
-    /// <summary>
-    /// Process the request to create a new group.
-    /// <br/>- Sends a request through RPC to:
-    /// <br/>- GroupRepository
-    /// </summary>
-    /// <param name="request"><see cref="PostGroup"/></param>
-    /// <returns>An <see cref="IActionResult"/> of <see cref="GroupResponse"/></returns>
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GroupResponse))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
@@ -100,34 +133,51 @@ public class GroupController : ControllerBase {
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(string))]
     public async Task<ActionResult<GroupResponse>> Create([FromBody] PostGroup request) {
         try {
-
-            // Create request object to send to the group repository
             var createGroupReq = new CreateGroupReq() {
                 OwnerId = request.OwnerId,
                 Name = request.Name,
                 Token = GenerateGroupToken()
             };
 
-            // Sends the request to the group repository
-            var response = await _rpcClient.CallAsync(Operation.CreateGroup, createGroupReq);
+            var response = await _policies.ExecuteAsync(async () =>
+            {
+                var rpcResponse = await _rpcClient.CallAsync(Operation.CreateGroup, createGroupReq);
+                return new HttpResponseMessage()
+                {
+                    Content = new StringContent(rpcResponse)
+                };
+            });
 
-            // Deserializes the response and returns it
-            var group = JsonConvert.DeserializeObject<GroupResponse>(response);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var group = JsonConvert.DeserializeObject<GroupResponse>(responseContent);
             return Ok(group);
+        }
+        catch (BrokenCircuitException)
+        {
+            Monitoring.Monitoring.Log.Error("Create::Circuit breaker is open, fallback strategy launched.");
+            var client = _clientFactory.CreateClient("GroupRepoHTTP");
+            var jsonRequest = System.Text.Json.JsonSerializer.Serialize(request);
+            var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, "application/json");
+            var response = await client.PostAsync($"http://group-repo:8080/group", content);
 
-        } catch (Exception e) {
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            var result = System.Text.Json.JsonSerializer.Deserialize<GroupResponse>(jsonResponse,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            return Ok(result);
+        }
+        catch (RpcTimeoutException)
+        {
+            return StatusCode(StatusCodes.Status408RequestTimeout, "Request timed out");
+        }
+        catch (Exception e)
+        {
             Monitoring.Monitoring.Log.Error("Error creating group");
             Console.WriteLine(e);
             return StatusCode(StatusCodes.Status500InternalServerError, "Couldn't deserialize the response");
         }
     }
 
-    /// <summary>
-    /// Process the request to join a group.
-    /// <br/>- Sends a request through RPC to:
-    /// <br/>- GroupRepository
-    /// </summary>
-    /// <param name="request"><see cref="JoinGroupReq"/></param>
     [HttpPost("join")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
@@ -135,19 +185,40 @@ public class GroupController : ControllerBase {
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(string))]
     public async Task<IActionResult> Join([FromBody] JoinGroupReq request) {
         try {
-            // Create request object to send to the group repository
             var joinGroupReq = new JoinGroupReq() {
                 UserId = request.UserId,
                 Token = request.Token
             };
 
-            // Sends the request to the group repository
-            var response = await _rpcClient.CallAsync(Operation.JoinGroup, joinGroupReq);
-            var contentString = JsonConvert.DeserializeObject<string>(response);
+            var response = await _policies.ExecuteAsync(async () =>
+            {
+                var rpcResponse = await _rpcClient.CallAsync(Operation.JoinGroup, joinGroupReq);
+                return new HttpResponseMessage()
+                {
+                    Content = new StringContent(rpcResponse)
+                };
+            });
 
-            return Ok(contentString);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            return Ok(responseContent);
+        }
+        catch (BrokenCircuitException)
+        {
+            Monitoring.Monitoring.Log.Error("Join::Circuit breaker is open, fallback strategy launched.");
+            var client = _clientFactory.CreateClient("GroupRepoHTTP");
+            var jsonRequest = System.Text.Json.JsonSerializer.Serialize(request);
+            var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, "application/json");
+            var response = await client.PostAsync($"http://group-repo:8080/group/join", content);
 
-        } catch (Exception e) {
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            return Ok(jsonResponse);
+        }
+        catch (RpcTimeoutException)
+        {
+            return StatusCode(StatusCodes.Status408RequestTimeout, "Request timed out");
+        }
+        catch (Exception e)
+        {
             Monitoring.Monitoring.Log.Error("Error joining group");
             Console.WriteLine(e);
             return StatusCode(StatusCodes.Status500InternalServerError, "Couldn't deserialize the response");

--- a/deployable/GroupService/GroupService.csproj
+++ b/deployable/GroupService/GroupService.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.2" />
+        <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 

--- a/deployable/GroupService/Program.cs
+++ b/deployable/GroupService/Program.cs
@@ -1,5 +1,7 @@
 ﻿using Messages.RPC;
 using Microsoft.Extensions.Options;
+using Polly;
+using Polly.Extensions.Http;
 using RPC;
 using RPC.RpcFactory;
 
@@ -10,9 +12,49 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddControllers();
 
 // Add HTTP client
-builder.Services.AddHttpClient();
+builder.Services.AddHttpClient(); 
+builder.Services.AddHttpClient("GroupRepoHTTP", client => {
+    client.BaseAddress = new Uri("http://group-repo:8080");
+});
+// HTTP Circuit breakers
+
+var retryPolicy = HttpPolicyExtensions
+    .HandleTransientHttpError()
+    .Or<RpcTimeoutException>()
+    .WaitAndRetryAsync(1, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)), onRetry: (outcome, timespan, retryAttempt, context) =>
+    {
+        Console.WriteLine($"Retrying... attempt {retryAttempt}");
+    });
+
+var circuitBreakerPolicy = HttpPolicyExtensions
+    .HandleTransientHttpError()
+    .Or<RpcTimeoutException>()
+    .CircuitBreakerAsync(1, TimeSpan.FromSeconds(30), onBreak: (outcome, timespan) =>
+    {
+        Console.WriteLine("Circuit breaker opened!");
+    }, onReset: () =>
+    {
+        Console.WriteLine("Circuit breaker reset!");
+    });
+
+var timeoutPolicy = Policy.TimeoutAsync<HttpResponseMessage>(TimeSpan.FromSeconds(30), (context, timeSpan, task) => {
+    return Task.FromException<HttpResponseMessage>(new RpcTimeoutException("Request timed out."));
+});
+
+// Wrapping the policies in the correct order: timeoutPolicy should be the outermost
+var policies = Policy.WrapAsync(retryPolicy, circuitBreakerPolicy,timeoutPolicy);
+builder.Services.AddSingleton<IAsyncPolicy<HttpResponseMessage>>(policies);
 
 
+// Configure topics
+builder.Services.AddSingleton<IConnectionFactoryProvider, RpcFactory>();
+builder.Services.Configure<Topics>(builder.Configuration.GetSection("RPCMessages"));
+builder.Services.AddSingleton<RpcClient>(provider =>
+    new RpcClient(
+        provider.GetRequiredService<IOptions<Topics>>().Value.Topic,
+        provider.GetRequiredService<IConnectionFactoryProvider>()
+    )
+);
 // Configure topics
 builder.Services.AddSingleton<IConnectionFactoryProvider, RpcFactory>();
 builder.Services.Configure<Topics>(builder.Configuration.GetSection("RPCMessages"));


### PR DESCRIPTION
Added the HTTP Fallback strategy in User, Group and Expense Services.

- Circuit Breaker and RpcTimeOutException implemented
- Fallback startegy using the HTTP access to the related Repos
- Execution of the policy through async method instead of HTTP client call.